### PR TITLE
Fixed imageURL for orlando policiccio

### DIFF
--- a/slack_startup_users.json
+++ b/slack_startup_users.json
@@ -481,7 +481,7 @@
             },
             "properties": {
                 "name": "Orlando Policicchio",
-                "imageURL": "https://www.company-mood.com/assets/logos/company_mood_logo-b537e901c34099ac41c25aa1255efe5a.png",
+                "imageURL": "https://www.company-mood.com/assets/logos/company_mood_logo@2.png",
                 "contact": {
                     "company": "CompanyMood",
                     "role": "Co-Founder",


### PR DESCRIPTION
My cofounder took a temporary logo url. I replaced it with a peristant one. :smile: